### PR TITLE
use platform-specific path separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var dust = require('dustjs-linkedin');
 
 module.exports = function(content) {
@@ -5,7 +6,8 @@ module.exports = function(content) {
     this.cacheable();
   }
 
-  var name = this.resourcePath.replace(this.options.context + '/', '').replace('.dust', ''),
+
+  var name = this.resourcePath.replace(this.options.context + path.sep, '').replace('.dust', '').replace(path.sep, '/'),
     compiled = dust.compile(content, name);
 
   return "module.exports = " + compiled;


### PR DESCRIPTION
Windows uses "\" as a path separator. This normalizes things so we can
use "/" in the require() call and not break the absolute path returned
from context. The third replace() call in Unix is a no-op.
