### PR TITLE
use platform-specific path separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(content) {
   }
 
 
-  var name = this.resourcePath.replace(this.options.context + path.sep, '').replace('.dust', '').replace(path.sep, '/'),
+  var name = this.resourcePath.replace(this.options.context + path.sep, '').replace('.dust', '').split(path.sep).join('/'),
     compiled = dust.compile(content, name);
 
   return "module.exports = " + compiled;


### PR DESCRIPTION
Windows uses "\" as a path separator. This patch normalizes things so we can still use forward slashes in the require() call and not break the absolute path returned from context.
